### PR TITLE
[D3DValidate] fix deallocation mismatch

### DIFF
--- a/D3DValidate/D3DValidate.cpp
+++ b/D3DValidate/D3DValidate.cpp
@@ -252,7 +252,7 @@ bool D3DValidateTriangle(float *verts, MaskedOcclusionCulling *moc)
 		}
 	}
 
-	delete depthBuffer;
+	delete[] depthBuffer;
 	delete[] d3dimg;
 
 	return identical;


### PR DESCRIPTION
When we allocate an array using the new …[…] syntax, we should deallocate it using delete[]. In these cases, we needed to change delete to delete[]. If we use the wrong form of delete to match our allocation with new, we have undefined behavior.
