### PR TITLE
Fixed command line arguments for the MSVC compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,29 @@ else()
 	set(CMAKE_CXX_FLAGS "-std=c++11 -m64")
 endif()
 
+if(MSVC)
+#
+# Setup compiler flags for AVX-512 files (MSVC)
+#
+
+if (USE_AVX512)
+	SET_SOURCE_FILES_PROPERTIES( ${MOC_AVX512_FILES} PROPERTIES COMPILE_FLAGS "-DUSE_AVX512=1 /arch:AVX2" )
+else()
+	SET_SOURCE_FILES_PROPERTIES( ${MOC_AVX512_FILES} PROPERTIES COMPILE_FLAGS "/arch:AVX2" )
+endif()
+
+#
+# Setup compiler flags for AVX2 files (MSVC)
+#
+SET_SOURCE_FILES_PROPERTIES( ${MOC_AVX2_FILES} PROPERTIES COMPILE_FLAGS "/arch:AVX2" )
+
+#
+# Setup compiler flags for SSE4.1 / SSE2 files (MSVC)
+#
+SET_SOURCE_FILES_PROPERTIES( ${MOC_SSE_FILES} PROPERTIES COMPILE_FLAGS "/arch:SSE2" )
+
+else()
+
 #
 # Setup compiler flags for AVX-512 files
 #
@@ -41,6 +64,8 @@ SET_SOURCE_FILES_PROPERTIES( ${MOC_AVX2_FILES} PROPERTIES COMPILE_FLAGS "-mavx2 
 # Setup compiler flags for SSE4.1 / SSE2 files
 #
 SET_SOURCE_FILES_PROPERTIES( ${MOC_SSE_FILES} PROPERTIES COMPILE_FLAGS "-msse4.1" )
+
+endif()
 
 #
 # Create masked occlusion culling library


### PR DESCRIPTION
`-mavx2`, `-mfma`, `-msse4.1` etc are not valid command line arguments for MSVC.