### PR TITLE
Configure install step in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,3 +83,6 @@ add_library( MaskedOcclusionCulling ${MOC_FILES} )
 # Add folder to include path
 #
 target_include_directories(MaskedOcclusionCulling PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+install(FILES MaskedOcclusionCulling.h FrameRecorder.h CullingThreadpool.h TYPE INCLUDE)
+install(TARGETS MaskedOcclusionCulling ARCHIVE LIBRARY RUNTIME)


### PR DESCRIPTION
Configure the install step in CMakeLists.txt, so the built library and its header are placed in the correct directories.